### PR TITLE
Add instructions where to place the OCR Space API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ php artisan vendor:publish --provider="Codesmiths\LaravelOcrSpace\LaravelOcrSpac
 
 You can get a free api key from [ocr.space](https://ocr.space/ocrapi/freekey). This key is required to use the package.
 
+You should add this key to your `.env`:
+
+```
+OCR_SPACE_API_KEY="YOUR API KEY"
+```
+
 ### Parsing an Image file
 
 ```php


### PR DESCRIPTION
This PR expands on the documentation to tell users where to put the API key without needing to dig into the config.