### PR TITLE
Add a MissingOcrSpaceOptionException

### DIFF
--- a/src/Exceptions/MissingOcrSpaceOptionException.php
+++ b/src/Exceptions/MissingOcrSpaceOptionException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codesmiths\LaravelOcrSpace\Exceptions;
+
+use InvalidArgumentException;
+
+class MissingOcrSpaceOptionException extends InvalidArgumentException
+{
+    public static function forProperty(string $property, string $purpose, int $code = 0, ?\Throwable $previous = null): self
+    {
+        $message = "The [$property] property is required in the OcrSpaceOptions $purpose.";
+
+        return new self($message, $code, $previous);
+    }
+}

--- a/src/OcrSpace.php
+++ b/src/OcrSpace.php
@@ -6,6 +6,7 @@ namespace Codesmiths\LaravelOcrSpace;
 
 use Codesmiths\LaravelOcrSpace\Enums\InputType;
 use Codesmiths\LaravelOcrSpace\Exceptions\InvalidRequestException;
+use Codesmiths\LaravelOcrSpace\Exceptions\MissingOcrSpaceOptionException;
 use Codesmiths\LaravelOcrSpace\ValueObjects\OcrSpaceResponse;
 use Illuminate\Support\Facades\Http;
 
@@ -152,7 +153,7 @@ class OcrSpace
     public function parseBinaryImage(string $binary, OcrSpaceOptions $options): OcrSpaceResponse
     {
         if ($options->fileType === null) {
-            throw new \Exception('The file type is required for binary images in the options.');
+            throw MissingOcrSpaceOptionException::forProperty('fileType', 'when parsing binary images');
         }
 
         return $this->parseBase64Image(base64_encode($binary), $options);
@@ -161,7 +162,7 @@ class OcrSpace
     public function parseBase64Image(string $base64, OcrSpaceOptions $options): OcrSpaceResponse
     {
         if ($options->fileType === null) {
-            throw new \Exception('The file type is required for base64 images in the OcrSpaceOptions.');
+            throw MissingOcrSpaceOptionException::forProperty('fileType', 'when parsing base64 images');
         }
 
         return $this->parseImage(InputType::Base64, 'data:'.$options->fileType.';base64,'.$base64, $options);

--- a/tests/Unit/OcrSpaceTest.php
+++ b/tests/Unit/OcrSpaceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Codesmiths\LaravelOcrSpace\Exceptions\MissingOcrSpaceOptionException;
+
 it('parses an image file', function (): void {
     $filePath = __DIR__.'/../Fixtures/test-image.png';
     $service = new \Codesmiths\LaravelOcrSpace\OcrSpace;
@@ -32,6 +34,17 @@ it('parses a binary image', function (): void {
         ->and($response->getParsedResults())->count(1);
 });
 
+it('throws a MissingOcrSpaceOptionException if the fileType option is missing when parsing a binary image', function () {
+    $filePath = __DIR__.'/../Fixtures/test-image.png';
+    $service = new \Codesmiths\LaravelOcrSpace\OcrSpace;
+    $options = new \Codesmiths\LaravelOcrSpace\OcrSpaceOptions;
+
+    expect(fn () => $service->parseBinaryImage(
+        file_get_contents($filePath),
+        $options,
+    ))->toThrow(MissingOcrSpaceOptionException::class, 'The [fileType] property is required in the OcrSpaceOptions when parsing binary images.');
+});
+
 it('parses a base64 image', function (): void {
     $filePath = __DIR__.'/../Fixtures/test-image.png';
     $service = new \Codesmiths\LaravelOcrSpace\OcrSpace;
@@ -46,6 +59,17 @@ it('parses a base64 image', function (): void {
     expect($response)->toBeInstanceOf(\Codesmiths\LaravelOcrSpace\ValueObjects\OcrSpaceResponse::class)
         ->and($response->hasError())->toBeFalse()
         ->and($response->getParsedResults())->count(1);
+});
+
+it('throws a MissingOcrSpaceOptionException if the fileType option is missing when parsing a base64 image', function () {
+    $filePath = __DIR__.'/../Fixtures/test-image.png';
+    $service = new \Codesmiths\LaravelOcrSpace\OcrSpace;
+    $options = new \Codesmiths\LaravelOcrSpace\OcrSpaceOptions;
+
+    expect(fn () => $service->parseBase64Image(
+        base64_encode(file_get_contents($filePath)),
+        $options,
+    ))->toThrow(MissingOcrSpaceOptionException::class, 'The [fileType] property is required in the OcrSpaceOptions when parsing base64 images.');
 });
 
 it('parses an image url', function (): void {


### PR DESCRIPTION
This PR adds a MissingOcrSpaceOptionException to allow for more granular exception handling.

As this new exception inherits from InvalidArgumentException (which in turn inherits from Exception), this change does not introduce any BC breaks.