### PR TITLE
Fixed composer require package name in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Laravel OCR Space is a package that allows you to use the [OCR.Space](https://oc
 You can install the package via composer:
 
 ```bash
-composer require cdsmiths/laravel-ocr-space
+composer require cdsmths/laravel-ocr-space
 ```
 
 You can publish the config file with:


### PR DESCRIPTION
This PR fixes the package name issue in the `readme.md` doc.

`composer require cdsmiths/laravel-ocr-space` 