### PR TITLE
Correct file group for publishing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require cdsmths/laravel-ocr-space
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Codesmiths\LaravelOcrSpace\LaravelOcrSpaceServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Codesmiths\LaravelOcrSpace\LaravelOcrSpaceServiceProvider" --tag="laravel-ocr-space"
 ```
 
 ## Usage


### PR DESCRIPTION
The config didn't publish because of a wrong file group in the readme.