### PR TITLE
Add auto language (OCR Engine 2 only)

### DIFF
--- a/src/Enums/Language.php
+++ b/src/Enums/Language.php
@@ -4,6 +4,7 @@ namespace Codesmiths\LaravelOcrSpace\Enums;
 
 enum Language: string
 {
+    case Auto = 'auto';
     case Arabic = 'ara';
     case Bulgarian = 'bul';
     case ChineseSimplified = 'chs';


### PR DESCRIPTION
OCR Engine 2 allow the auto language detection option.

OCR Engine 1 doesn't support it.