### PR TITLE
docs: Fix typo on response in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $response->getProcessingTimeInMilliseconds(); // Returns the processing time in 
 $response->getSearchablePdfUrl(); // Returns the searchable pdf url
 $response->hasSearchablePdfUrl(); // Returns if the response has a searchable pdf url
 $response->hasError(); // Returns if the response has an error
-$repsonse->hasParsedResults(); // Returns if the response has parsed results
+$response->hasParsedResults(); // Returns if the response has parsed results
 ```
 
 # License / Credits


### PR DESCRIPTION
Fix Typo in README.md

There is a typo in "Response" section so I fix it. Because, when someone copy paste it, someone need fix the typo before using it. 

I hope this pull request make anyone who use it more comfortable. 

Thank you