### PR TITLE
docs: Add documentation about getParsedResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ $response->hasError(); // Returns if the response has an error
 $repsonse->hasParsedResults(); // Returns if the response has parsed results
 ```
 
+### Parsed Results
+
+If you want to get value from `getParsedResults()`, you can use the following methods:
+
+```php
+$parsedResults = $response->getParsedResults();
+
+$parsedResults->first()->getParsedText(), // Returns the parsed text from the first parsed result
+$parsedResults->first()->getTextOverlay(), // Returns the text overlay from the first parsed result
+$parsedResults->first()->getFileParseExitCode(), // Returns the file parse exit code from the first parsed result
+$parsedResults->first()->getErrorMessage(), // Returns the error message from the first parsed result
+$parsedResults->first()->getErrorDetails(), // Returns the error message details from the first parsed result
+$parsedResults->first()->getSerializedParsedText(), // Returns the serialized parsed text from the first parsed result
+```
+
+
 # License / Credits
 
 This package our Codesmiths is not affiliated with [OCR.Space](https://ocr.space/ocrapi) and is not an official package. It is a wrapper around the OCR.Space API.


### PR DESCRIPTION
Add new documentation about getParsedResults

Add new documentation about get value in getParsedResults().

Why I add this?
When I using this repository, I spend 30-60 minutes to know "How to get only parsed result text?". I cannot access it using '$response->getParsedResults()->first()->parsedText'. After spend some time, you can get text using 'getParsedText()'. Maybe, if some of beginner access it, it'll more easier to read this doc rather than see parsedResults() in laravel-ocr-space package.

Thank you
